### PR TITLE
default path & content header change for selenium 4

### DIFF
--- a/src/01_structs/04_WebDriver.jl
+++ b/src/01_structs/04_WebDriver.jl
@@ -2,7 +2,7 @@
 	RemoteWebDriver(capabilities::Capabilities;
                     host::AbstractString = "localhost",
                     port::Integer = 4444,
-                    path::AbstractString = "/wd/hub",
+                    path::AbstractString = "",
 					kwargs...)::RemoteWebDriver
 
 Specifies a remote web driver according to [W3C](https://www.w3.org/TR/webdriver).

--- a/src/01_structs/04_WebDriver.jl
+++ b/src/01_structs/04_WebDriver.jl
@@ -25,7 +25,7 @@ struct RemoteWebDriver{C<:Capabilities}
         capabilities::Capabilities;
         host::AbstractString = "localhost",
         port::Integer = 4444,
-        path::AbstractString = "/wd/hub",
+        path::AbstractString = "",
         kwargs...,
     )::RemoteWebDriver
         addr = URI(scheme = "http", host = host, port = port, path = path)

--- a/src/01_structs/05_Session.jl
+++ b/src/01_structs/05_Session.jl
@@ -25,7 +25,7 @@ struct Session{D<:Object}
         @unpack addr = wd
         response = HTTP.post(
             "$(wd.addr)/session",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
             JSON3.write(Dict("desiredCapabilities" => wd.capabilities, wd.kw...)),
         )
         @assert response.status == 200

--- a/src/01_structs/06_Element.jl
+++ b/src/01_structs/06_Element.jl
@@ -39,7 +39,7 @@ struct Element
         # value = "//select[@id='selecttype']"
         response = HTTP.post(
             "$addr/session/$id/element",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
             JSON3.write(Dict("using" => location_strategy, "value" => value)),
         )
         @assert response.status == 200
@@ -58,7 +58,7 @@ struct Element
         element_id = element.id
         response = HTTP.post(
             "$addr/session/$id/element/$element_id/element",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
             JSON3.write(Dict("using" => location_strategy, "value" => value)),
         )
         @assert response.status == 200

--- a/src/01_structs/07_Errors.jl
+++ b/src/01_structs/07_Errors.jl
@@ -7,7 +7,7 @@ struct WDError <: Exception
     error::String
     message::String
     function WDError(err::StatusError)
-        json = JSON3.read(err.response.body).value
+        json = JSON3.read(err.response.body)
         new(err.status, json.error, json.message)
     end
 end

--- a/src/02_commands/01_Sessions/02_Delete_Session.jl
+++ b/src/02_commands/01_Sessions/02_Delete_Session.jl
@@ -7,7 +7,7 @@ function delete!(session::Session)
     try
         @unpack addr, id = session
         response =
-            HTTP.delete("$addr/session/$id", [("Content-Type" => "application/json")])
+            HTTP.delete("$addr/session/$id", [("Content-Type" => "application/json; charset=utf-8")])
         @assert response.status == 200
         @assert JSON3.read(response.body).status == 0
         id

--- a/src/02_commands/01_Sessions/03_Status.jl
+++ b/src/02_commands/01_Sessions/03_Status.jl
@@ -5,7 +5,7 @@ Returns `true` if the server is running and ready to accept new sessions.
 """
 function status(wd::RemoteWebDriver)::Bool
     @unpack addr = wd
-    response = HTTP.get("$addr/status", [("Content-Type" => "application/json")])
+    response = HTTP.get("$addr/status", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     json = JSON3.read(response.body).value
     json.ready

--- a/src/02_commands/02_Timeouts/01_Get_Timeouts.jl
+++ b/src/02_commands/02_Timeouts/01_Get_Timeouts.jl
@@ -7,7 +7,7 @@ Currently not supported by Selenium.
 function timeouts(session::Session)
     @unpack addr, id = session
     response =
-        HTTP.get("$addr/session/$id/timeouts", [("Content-Type" => "application/json")])
+        HTTP.get("$addr/session/$id/timeouts", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).status
 end

--- a/src/02_commands/02_Timeouts/02_Set_Timeouts.jl
+++ b/src/02_commands/02_Timeouts/02_Set_Timeouts.jl
@@ -7,7 +7,7 @@ function timeouts!(session::Session, timeouts::Timeouts)::Nothing
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/timeouts",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(timeouts),
     )
     @assert response.status == 200

--- a/src/02_commands/03_Navigation/01_Navigate_To.jl
+++ b/src/02_commands/03_Navigation/01_Navigate_To.jl
@@ -10,7 +10,7 @@ function navigate!(session::Session, url::AbstractString)
         @unpack addr, id = session
         response = HTTP.post(
             "$addr/session/$id/url",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
             """{"url": "$url"}""",
         )
         nothing

--- a/src/02_commands/03_Navigation/02_Get_Current_URL.jl
+++ b/src/02_commands/03_Navigation/02_Get_Current_URL.jl
@@ -6,7 +6,7 @@ Get Current URL.
 """
 function current_url(session::Session)::String
     @unpack addr, id = session
-    response = HTTP.get("$addr/session/$id/url", [("Content-Type" => "application/json")])
+    response = HTTP.get("$addr/session/$id/url", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).value
 end

--- a/src/02_commands/03_Navigation/03_Back.jl
+++ b/src/02_commands/03_Navigation/03_Back.jl
@@ -7,7 +7,7 @@ This is equivalent to pressing the back button in the browser chrome or invoking
 """
 function back!(session::Session)
     @unpack addr, id = session
-    response = HTTP.post("$addr/session/$id/back", [("Content-Type" => "application/json")])
+    response = HTTP.post("$addr/session/$id/back", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     nothing
 end

--- a/src/02_commands/03_Navigation/04_Forward.jl
+++ b/src/02_commands/03_Navigation/04_Forward.jl
@@ -7,7 +7,7 @@ This command causes the browser to traverse one step forwards in the joint sessi
 function forward!(session::Session)
     @unpack addr, id = session
     response =
-        HTTP.post("$addr/session/$id/forward", [("Content-Type" => "application/json")])
+        HTTP.post("$addr/session/$id/forward", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     nothing
 end

--- a/src/02_commands/03_Navigation/05_Refresh.jl
+++ b/src/02_commands/03_Navigation/05_Refresh.jl
@@ -7,7 +7,7 @@ This command causes the browser to reload the page in the current top-level brow
 function refresh!(session::Session)
     @unpack addr, id = session
     response =
-        HTTP.post("$addr/session/$id/timeouts", [("Content-Type" => "application/json")])
+        HTTP.post("$addr/session/$id/timeouts", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     nothing
 end

--- a/src/02_commands/03_Navigation/06_Get_Title.jl
+++ b/src/02_commands/03_Navigation/06_Get_Title.jl
@@ -6,7 +6,7 @@ This command returns the document title of the current top-level browsing contex
 """
 function document_title(session::Session)::String
     @unpack addr, id = session
-    response = HTTP.get("$addr/session/$id/title", [("Content-Type" => "application/json")])
+    response = HTTP.get("$addr/session/$id/title", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).value
 end

--- a/src/02_commands/04_Contexts/01_Get_Window_Handle.jl
+++ b/src/02_commands/04_Contexts/01_Get_Window_Handle.jl
@@ -8,7 +8,7 @@ function window_handle(session::Session)::String
     @unpack addr, id = session
     response = HTTP.get(
         "$addr/session/$id/window_handle",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     convert(String, JSON3.read(response.body).value)

--- a/src/02_commands/04_Contexts/02_Close_Window.jl
+++ b/src/02_commands/04_Contexts/02_Close_Window.jl
@@ -7,7 +7,7 @@ The window handle associated with the current top-level browsing context.
 function window_close!(session::Session)::Nothing
     @unpack addr, id = session
     response =
-        HTTP.delete("$addr/session/$id/window", [("Content-Type" => "application/json")])
+        HTTP.delete("$addr/session/$id/window", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     nothing
 end

--- a/src/02_commands/04_Contexts/03_Switch_To_Window.jl
+++ b/src/02_commands/04_Contexts/03_Switch_To_Window.jl
@@ -8,7 +8,7 @@ function window!(session::Session, handle::AbstractString)
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/window",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write("handle" => handle),
     )
     @assert response.status == 200

--- a/src/02_commands/04_Contexts/04_Get_Window_Handles.jl
+++ b/src/02_commands/04_Contexts/04_Get_Window_Handles.jl
@@ -9,7 +9,7 @@ function window_handles(session::Session)::Vector{String}
     @unpack addr, id = session
     response = HTTP.get(
         "$addr/session/$id/window_handles",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     convert(Vector{String}, JSON3.read(response.body).value)::Vector{String}

--- a/src/02_commands/04_Contexts/05_New_Window.jl
+++ b/src/02_commands/04_Contexts/05_New_Window.jl
@@ -7,7 +7,7 @@ Create a new top-level browsing context.
 function window!(session::Session)::NamedTuple{(:type, :handle),NTuple{2, String}}
     @unpack addr, id = session
     response =
-        HTTP.post("$addr/session/$id/window/new", [("Content-Type" => "application/json")])
+        HTTP.post("$addr/session/$id/window/new", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     result = JSON3.read(response.body, NamedTuple)
     @assert result.status == 0

--- a/src/02_commands/04_Contexts/06_Switch_To_Frame.jl
+++ b/src/02_commands/04_Contexts/06_Switch_To_Frame.jl
@@ -9,7 +9,7 @@ function frame! end
 #     @unpack addr, id = session
 #     response = HTTP.post(
 #         "$addr/session/$id/frame",
-#         [("Content-Type" => "application/json")],
+#         [("Content-Type" => "application/json; charset=utf-8")],
 #         JSON3.write(Dict("id" => nothing))),
 #     )
 #     @assert response.status == 200
@@ -18,7 +18,7 @@ function frame!(frame::Element)::Nothing
     @unpack addr, id = frame.session
     response = HTTP.post(
         "$addr/session/$id/frame",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("id" => ("ELEMENT" => frame.id))),
     )
     @assert response.status == 200

--- a/src/02_commands/04_Contexts/07_Switch_To_Parent_Frame.jl
+++ b/src/02_commands/04_Contexts/07_Switch_To_Parent_Frame.jl
@@ -8,7 +8,7 @@ function parent_frame!(session::Session)
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/frame/parent",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
 end

--- a/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/01_Get_Window_Rect.jl
+++ b/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/01_Get_Window_Rect.jl
@@ -11,7 +11,7 @@ function rect(
     @unpack addr, id = session
     response = HTTP.get(
         "$addr/session/$id/window/$window/size",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     output = JSON3.read(response.body).value

--- a/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/02_Set_Window_Rect.jl
+++ b/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/02_Set_Window_Rect.jl
@@ -17,7 +17,7 @@ function rect!(
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/window/$window/size",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("width" => width, "height" => height)),
     )
     @assert response.status == 200

--- a/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/03_Maximize_Window.jl
+++ b/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/03_Maximize_Window.jl
@@ -13,7 +13,7 @@ function maximize!(session::Session; window::AbstractString = "current")
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/window/$window/maximize",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     output = JSON3.read(response.body).value

--- a/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/04_Minimize_Window.jl
+++ b/src/02_commands/04_Contexts/08_Resizing_and_positioning_windows/04_Minimize_Window.jl
@@ -17,7 +17,7 @@ function minimize!(
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/window/$window/minimize",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     output = JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/01_Retrieval/01_Get_Active_Element.jl
+++ b/src/02_commands/05_Elements/01_Retrieval/01_Get_Active_Element.jl
@@ -8,7 +8,7 @@ function active_element(session::Session)::Element
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/element/active",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     Element(session, first(values(JSON3.read(response.body).value)))

--- a/src/02_commands/05_Elements/01_Retrieval/03_Find_Elements.jl
+++ b/src/02_commands/05_Elements/01_Retrieval/03_Find_Elements.jl
@@ -17,7 +17,7 @@ function Elements(
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/elements",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("using" => location_strategy, "value" => value)),
     )
     @assert response.status == 200

--- a/src/02_commands/05_Elements/01_Retrieval/05_Find_Elements_from_Element.jl
+++ b/src/02_commands/05_Elements/01_Retrieval/05_Find_Elements_from_Element.jl
@@ -18,7 +18,7 @@ function Elements(
     element_id = element.id
     response = HTTP.post(
         "$addr/session/$id/element/$element_id/elements",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("using" => location_strategy, "value" => value)),
     )
     @assert response.status == 200

--- a/src/02_commands/05_Elements/02_State/01_Is_Element_Selected.jl
+++ b/src/02_commands/05_Elements/02_State/01_Is_Element_Selected.jl
@@ -10,7 +10,7 @@ function isselected(element::Element)::Bool
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/selected",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/02_Get_Element_Attribute.jl
+++ b/src/02_commands/05_Elements/02_State/02_Get_Element_Attribute.jl
@@ -9,7 +9,7 @@ function element_attr(element::Element, attribute::AbstractString)
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/attribute/$attribute",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/03_Get_Element_Property.jl
+++ b/src/02_commands/05_Elements/02_State/03_Get_Element_Property.jl
@@ -9,7 +9,7 @@ function element_property(element::Element, property::AbstractString)
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/property/$property",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/04_Get_Element_CSS_Value.jl
+++ b/src/02_commands/05_Elements/02_State/04_Get_Element_CSS_Value.jl
@@ -9,7 +9,7 @@ function element_css(element::Element, value::AbstractString)
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/css/$value",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/05_Get_Element_Text.jl
+++ b/src/02_commands/05_Elements/02_State/05_Get_Element_Text.jl
@@ -10,7 +10,7 @@ function element_text(element::Element)::String
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/text",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/06_Get_Element_Tag_Name.jl
+++ b/src/02_commands/05_Elements/02_State/06_Get_Element_Tag_Name.jl
@@ -9,7 +9,7 @@ function element_tag(element::Element)::String
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/name",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/07_Get_Element_Rect.jl
+++ b/src/02_commands/05_Elements/02_State/07_Get_Element_Rect.jl
@@ -14,7 +14,7 @@ function rect(element::Element)::NamedTuple{(:width, :height, :x, :y),NTuple{4,I
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/rect",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     output = JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/02_State/08_Is_Element_Enabled.jl
+++ b/src/02_commands/05_Elements/02_State/08_Is_Element_Enabled.jl
@@ -9,7 +9,7 @@ function isenabled(element::Element)::Bool
     element_id = element.id
     response = HTTP.get(
         "$addr/session/$id/element/$element_id/enabled",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/05_Elements/03_Interaction/01_Element_Click.jl
+++ b/src/02_commands/05_Elements/03_Interaction/01_Element_Click.jl
@@ -10,7 +10,7 @@ function click!(element::Element)::Nothing
     element_id = element.id
     response = HTTP.post(
         "$addr/session/$id/element/$element_id/click",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
 end

--- a/src/02_commands/05_Elements/03_Interaction/02_Element_Clear.jl
+++ b/src/02_commands/05_Elements/03_Interaction/02_Element_Clear.jl
@@ -9,7 +9,7 @@ function clear!(element::Element)::Nothing
     element_id = element.id
     response = HTTP.post(
         "$addr/session/$id/element/$element_id/clear",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
 end

--- a/src/02_commands/05_Elements/03_Interaction/03_Element_Send_Keys.jl
+++ b/src/02_commands/05_Elements/03_Interaction/03_Element_Send_Keys.jl
@@ -14,7 +14,7 @@ function element_keys!(element::Element, value::AbstractString)::Nothing
     element_id = element.id
     response = HTTP.post(
         "$addr/session/$id/element/$element_id/value",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write("value" => split(value, "")),
     )
     @assert response.status == 200

--- a/src/02_commands/06_Documents/01_Get_Page_Source.jl
+++ b/src/02_commands/06_Documents/01_Get_Page_Source.jl
@@ -7,7 +7,7 @@ The Get Page Source command returns a string serialization of the DOM of the cur
 function source(session::Session)::String
     @unpack addr, id = session
     response =
-        HTTP.get("$addr/session/$id/source", [("Content-Type" => "application/json")])
+        HTTP.get("$addr/session/$id/source", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).value
 end

--- a/src/02_commands/06_Documents/02_Execute_Script.jl
+++ b/src/02_commands/06_Documents/02_Execute_Script.jl
@@ -12,7 +12,7 @@ function script!(session::Session, _script::AbstractString, args...; async::Bool
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/execute$(async ? "_async" : "")",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict(
             "script" => _script,
             "args" => [isa(arg, Element) ? "ELEMENT" => arg.id : arg for arg in args],

--- a/src/02_commands/07_Cookies/01_Get_All_Cookies.jl
+++ b/src/02_commands/07_Cookies/01_Get_All_Cookies.jl
@@ -7,7 +7,7 @@ The Get Page Source command returns a string serialization of the DOM of the cur
 function cookies(session::Session)::Vector{Cookie}
     @unpack addr, id = session
     response =
-        HTTP.get("$addr/session/$id/cookie", [("Content-Type" => "application/json")])
+        HTTP.get("$addr/session/$id/cookie", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     convert(Vector{Cookie}, Cookie.(JSON3.read(response.body).value))
 end

--- a/src/02_commands/07_Cookies/02_Get_Named_Cookie.jl
+++ b/src/02_commands/07_Cookies/02_Get_Named_Cookie.jl
@@ -9,7 +9,7 @@ function cookie(session::Session, cookie::AbstractString)
     @unpack addr, id = session
     response = HTTP.get(
         "$addr/session/$id/cookie/$(escapeuri(cookie))",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/02_commands/07_Cookies/03_Add_Cookie.jl
+++ b/src/02_commands/07_Cookies/03_Add_Cookie.jl
@@ -8,7 +8,7 @@ function cookie!(session::Session, cookie::Cookie)::Nothing
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/cookie",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write("cookie" => cookie),
     )
     @assert response.status == 200

--- a/src/02_commands/07_Cookies/04_Delete_Cookie_Opt_All.jl
+++ b/src/02_commands/07_Cookies/04_Delete_Cookie_Opt_All.jl
@@ -9,13 +9,13 @@ function delete!(session::Session, cookie::AbstractString)::Nothing
     if isempty(cookie)
         response = HTTP.delete(
             "$addr/session/$id/cookie",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
         )
         @assert response.status == 200
     else
         response = HTTP.delete(
             "$addr/session/$id/cookie/$(escapeuri(cookie))",
-            [("Content-Type" => "application/json")],
+            [("Content-Type" => "application/json; charset=utf-8")],
         )
         @assert response.status == 200
     end

--- a/src/02_commands/08_Actions/01_Perform_Actions.jl
+++ b/src/02_commands/08_Actions/01_Perform_Actions.jl
@@ -6,7 +6,7 @@
 #     @unpack addr, id = session
 #     x = try
 #     response = HTTP.post("$addr/session/$id/actions",
-#                          [("Content-Type" => "application/json")],
+#                          [("Content-Type" => "application/json; charset=utf-8")],
 #                          JSON3.write("parameters" => "moveto!Element($(hoverOver.id))"))
 #     catch err
 #         err

--- a/src/02_commands/08_Actions/02_Move_To.jl
+++ b/src/02_commands/08_Actions/02_Move_To.jl
@@ -13,7 +13,7 @@ function moveto!(session::Session; x::Integer = 0, y::Integer = 0)
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/moveto!",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("x" => x, "y" => y)),
     )
     @assert response.status == 200
@@ -23,7 +23,7 @@ function moveto!(element::Element; x::Integer = 0, y::Integer = 0)
     @unpack addr, id = element.session
     response = HTTP.post(
         "$addr/session/$id/moveto",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("element" => element.id, "x" => x, "y" => y)),
     )
     @assert response.status == 200

--- a/src/02_commands/08_User_Prompts/01_Dismiss_Alert.jl
+++ b/src/02_commands/08_User_Prompts/01_Dismiss_Alert.jl
@@ -12,7 +12,7 @@ function dismiss(session::Session)
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/dismiss_alert",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
 end

--- a/src/02_commands/08_User_Prompts/02_Accept_Alert.jl
+++ b/src/02_commands/08_User_Prompts/02_Accept_Alert.jl
@@ -12,7 +12,7 @@ function accept(session::Session)::Nothing
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/accept_alert",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
 end

--- a/src/02_commands/08_User_Prompts/03_Get_Alert_Text.jl
+++ b/src/02_commands/08_User_Prompts/03_Get_Alert_Text.jl
@@ -11,7 +11,7 @@ Gets the text of the currently displayed JavaScript alert(), confirm(), or promp
 function alert_text(session::Session)::String
     @unpack addr, id = session
     response =
-        HTTP.get("$addr/session/$id/alert_text", [("Content-Type" => "application/json")])
+        HTTP.get("$addr/session/$id/alert_text", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).value
 end

--- a/src/02_commands/08_User_Prompts/04_Send_Alert_Text.jl
+++ b/src/02_commands/08_User_Prompts/04_Send_Alert_Text.jl
@@ -12,7 +12,7 @@ function alert_text!(session::Session, text::AbstractString)::Nothing
     @unpack addr, id = session
     response = HTTP.post(
         "$addr/session/$id/alert_text",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
         JSON3.write(Dict("text" => text)),
     )
     @assert response.status == 200

--- a/src/02_commands/09_Screen_Captures/01_Take_Screenshot.jl
+++ b/src/02_commands/09_Screen_Captures/01_Take_Screenshot.jl
@@ -11,7 +11,7 @@ function screenshot end
 function screenshot(session::Session)::String
     @unpack addr, id = session
     response =
-        HTTP.get("$addr/session/$id/screenshot", [("Content-Type" => "application/json")])
+        HTTP.get("$addr/session/$id/screenshot", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     JSON3.read(response.body).value
 end
@@ -19,7 +19,7 @@ function screenshot(element::Element)::String
     @unpack addr, id = element.session
     response = HTTP.get(
         "$addr/session/$id/element/$(element.id)/screenshot",
-        [("Content-Type" => "application/json")],
+        [("Content-Type" => "application/json; charset=utf-8")],
     )
     @assert response.status == 200
     JSON3.read(response.body).value

--- a/src/03_json_wire_protocol/01_sessions.jl
+++ b/src/03_json_wire_protocol/01_sessions.jl
@@ -9,7 +9,7 @@ Returns a list of the currently active sessions.
 """
 function sessions(wd::RemoteWebDriver)::Vector{String}
     @unpack addr = wd
-    response = HTTP.get("$addr/sessions", [("Content-Type" => "application/json")])
+    response = HTTP.get("$addr/sessions", [("Content-Type" => "application/json; charset=utf-8")])
     @assert response.status == 200
     output = JSON3.read(response.body).value
     isempty(output) ? Vector{String}() :


### PR DESCRIPTION
# default path & content header change for selenium 4

## Description

selenium 4 have changed host path from "/wd/hub" -> ""
also content-type header need to have charset included.
another bug about WDError construction:
json.value -> json

Some test case can not be execute, as the test dendent page is not available anymore.
But manual tests done.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
