### PR TITLE
Fix refresh command

### DIFF
--- a/src/02_commands/03_Navigation/05_Refresh.jl
+++ b/src/02_commands/03_Navigation/05_Refresh.jl
@@ -7,7 +7,7 @@ This command causes the browser to reload the page in the current top-level brow
 function refresh!(session::Session)
     @unpack addr, id = session
     response =
-        HTTP.post("$addr/session/$id/timeouts", [("Content-Type" => "application/json")])
+        HTTP.post("$addr/session/$id/refresh", [("Content-Type" => "application/json")])
     @assert response.status == 200
     nothing
 end


### PR DESCRIPTION
## Description

The `refresh!` command in its current state does not what it says, it only tries to post no data to the `timeouts` endpoint. This PR restores the desired outcome

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update